### PR TITLE
Duplicate datasource downstream and sync

### DIFF
--- a/change_sorting_key_to_s3_data_source/README.md
+++ b/change_sorting_key_to_s3_data_source/README.md
@@ -1,3 +1,44 @@
-# Tinybird Versions - {{ YOUR USE CASE NAME HERE }}
+# Change a Data Source Sorting Key
 
-Work in progress ...
+Altering a sorting key is a complex operation involving multiple steps and requires data migration.
+
+> Remember to follow the [instructions](../README.md) to setup your Tinybird Data Project before jumping into the use-case steps
+
+In this example we have changed the Landing Data Source to ingest from S3 appending these lines to the end of the file `analytics_events.datasource`
+
+```sql
+... 
+IMPORT_SERVICE 's3'
+IMPORT_CONNECTION_NAME 'TB-S3-1'
+IMPORT_BUCKET_URI 's3://webanalyticstb/v1/*.ndjson'
+IMPORT_STRATEGY 'append'
+IMPORT_SCHEDULE '@auto'
+```
+
+The strategy followed to change the sorting key is:
+1. Create the new Data Source with new Sorting Key and reading from a new S3 bucket/folder. In our example we're moving from `s3://webanalyticstb/v1/*.ndjson` to `s3://webanalyticstb/v2/*.ndjson`.
+2. Duplicate and Sync the downstream for the new Data Source (without changing the endpoints yet). The downstream are all the resources depending on your Data Source.
+3. Once the Data is in Sync change the endpoints to point the new downstream
+4. Start storing your new data in the new bucket/folder then you can remove legacy Data Source and its downstream.
+
+## Step 1 and 2: Downstream Replication and Sync Preparation
+This step involves cloning the Data Source whose sorting key we want to alter, along with all dependent Materialized Views, to create a new Downstream branch. This is where you will transition all relevant data to utilize the new Sorting Key.
+
+- Establish a new branch
+- Replicate your Data Source with the updated sorting key and bucket URI:
+  - `analytics_events.datasource` -> `analytics_events_new (using the new sorting key and bucket)`
+- Replicate all dependent resources. These include your Data Source and all Materialized Views and Pipes that link them. Do not clone or modify Pipe Endpoints at this time.
+  - `analytics_events.datasource` -> `analytics_events_new` (with the new sorting key)
+  - `analytics_pages_mv.datasource` -> `analytics_pages_mv_new.datasource`
+  - `analytics_sessions_mv.datasource` -> `analytics_session_mv_new.datasource`
+  - `analytics_sources_mv.datasource` -> `analytics_sources_mv_new.datasource`
+  - `analytics_sessions.pipe` -> `analytics_sessions_new.pipe` (alter to materialize on `analytics_sessions_mv_new.datasource`)
+  - `analytics_pages.pipe` -> `analytics_pages_new.pipe` (alter to materialize on `analytics_pages_mv_new.datasource`)
+  - `analytics_sources.pipe` -> `analytics_sources_new.pipe` (alter to materialize on `analytics_sources_mv_new.datasource`)
+  - `analytics_hits.pipe` -> `analytics_hits_new.pipe` (alter to query  `analytics_events_new.datasource`)
+- Create a Materialized Pipe (`new_data_sync.pipe`) to synchronize incoming data from the legacy Data Source to the new one. Implement a filter to sync data only beyond a specific future point. This sets the stage for the subsequent step.
+- Push the changes to the branch and initiate a Pull Request. The Continuous Integration (CI) process will validate the changes through Regression, Quality, and Fixture tests ([learn more about testing](https://www.tinybird.co/docs/guides/implementing-test-strategies.html)). 
+- Before merging, verify your adjustments in the temporary environment that is provisioned.
+- Merge the PR to trigger the Continuous Deployment (CD) workflow, and your changes will be propagated to the Main environment.
+
+View the pull request with all changes for this step: [PR Downstream replication](https://github.com/tinybirdco/use-case-examples/pull/22/files)

--- a/change_sorting_key_to_s3_data_source/README.md
+++ b/change_sorting_key_to_s3_data_source/README.md
@@ -1,4 +1,4 @@
-# Change a Data Source Sorting Key
+# Change an S3 Data Source Sorting Key
 
 Altering a sorting key is a complex operation involving multiple steps and requires data migration.
 

--- a/change_sorting_key_to_s3_data_source/datasources/analytics_events_new.datasource
+++ b/change_sorting_key_to_s3_data_source/datasources/analytics_events_new.datasource
@@ -1,0 +1,22 @@
+TOKEN "tracker" APPEND
+
+DESCRIPTION >
+    Analytics events landing data source
+
+SCHEMA >
+    `timestamp` DateTime `json:$.timestamp`,
+    `session_id` String `json:$.session_id`,
+    `action` LowCardinality(String) `json:$.action`,
+    `version` LowCardinality(String) `json:$.version`,
+    `payload` String `json:$.payload`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_SORTING_KEY "timestamp, action"
+ENGINE_TTL "timestamp + toIntervalDay(60)"
+
+IMPORT_SERVICE 's3'
+IMPORT_CONNECTION_NAME 'TB-S3-1'
+IMPORT_BUCKET_URI 's3://webanalyticstb/v2/*.ndjson'
+IMPORT_STRATEGY 'append'
+IMPORT_SCHEDULE '@auto'

--- a/change_sorting_key_to_s3_data_source/datasources/analytics_pages_mv_new.datasource
+++ b/change_sorting_key_to_s3_data_source/datasources/analytics_pages_mv_new.datasource
@@ -1,0 +1,13 @@
+
+SCHEMA >
+    `date` Date,
+    `device` String,
+    `browser` String,
+    `location` String,
+    `pathname` String,
+    `visits` AggregateFunction(uniq, String),
+    `hits` AggregateFunction(count)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(date)"
+ENGINE_SORTING_KEY "date, device, browser, location, pathname"

--- a/change_sorting_key_to_s3_data_source/datasources/analytics_sessions_mv_new.datasource
+++ b/change_sorting_key_to_s3_data_source/datasources/analytics_sessions_mv_new.datasource
@@ -1,0 +1,14 @@
+
+SCHEMA >
+    `date` Date,
+    `session_id` String,
+    `device` SimpleAggregateFunction(any, String),
+    `browser` SimpleAggregateFunction(any, String),
+    `location` SimpleAggregateFunction(any, String),
+    `first_hit` SimpleAggregateFunction(min, DateTime),
+    `latest_hit` SimpleAggregateFunction(max, DateTime),
+    `hits` AggregateFunction(count)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(date)"
+ENGINE_SORTING_KEY "date, session_id"

--- a/change_sorting_key_to_s3_data_source/datasources/analytics_sources_mv_new.datasource
+++ b/change_sorting_key_to_s3_data_source/datasources/analytics_sources_mv_new.datasource
@@ -1,0 +1,13 @@
+
+SCHEMA >
+    `date` Date,
+    `device` String,
+    `browser` String,
+    `location` String,
+    `referrer` String,
+    `visits` AggregateFunction(uniq, String),
+    `hits` AggregateFunction(count)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(date)"
+ENGINE_SORTING_KEY "date, device, browser, location, referrer"

--- a/change_sorting_key_to_s3_data_source/pipes/analytics_hits_new.pipe
+++ b/change_sorting_key_to_s3_data_source/pipes/analytics_hits_new.pipe
@@ -1,0 +1,59 @@
+DESCRIPTION >
+	Parsed `page_hit` events, implementing `browser` and `device` detection logic.
+
+
+TOKEN "dashboard" READ
+
+NODE parsed_hits
+DESCRIPTION >
+    Parse raw page_hit events
+
+SQL >
+
+    SELECT
+      timestamp,
+      action,
+      version,
+      coalesce(session_id,'0') as session_id,
+      JSONExtractString(payload, 'locale') as locale,
+      JSONExtractString(payload, 'location') as location,
+      JSONExtractString(payload, 'referrer') as referrer,
+      JSONExtractString(payload, 'pathname') as pathname,
+      JSONExtractString(payload, 'href') as href,
+      lower(JSONExtractString(payload, 'user-agent')) as user_agent
+    FROM
+      analytics_events_new
+    where action = 'page_hit'
+
+
+
+NODE endpoint
+SQL >
+
+    SELECT
+      timestamp,
+      action,
+      version,
+      session_id,
+      location,
+      referrer,
+      pathname,
+      href,
+      case
+        when match(user_agent, 'wget|ahrefsbot|curl|urllib|bitdiscovery|\+https://|googlebot') then 'bot'
+        when match(user_agent, 'android') then 'mobile-android'
+        when match(user_agent, 'ipad|iphone|ipod') then 'mobile-ios'
+        else 'desktop'
+      END as device,
+      case
+        when match(user_agent, 'firefox') then 'firefox'
+        when match(user_agent, 'chrome|crios') then 'chrome'
+        when match(user_agent, 'opera') then 'opera'
+        when match(user_agent, 'msie|trident') then 'ie'
+        when match(user_agent, 'iphone|ipad|safari') then 'safari'
+        else 'Unknown'
+      END as browser
+    FROM
+      parsed_hits
+
+

--- a/change_sorting_key_to_s3_data_source/pipes/analytics_pages_new.pipe
+++ b/change_sorting_key_to_s3_data_source/pipes/analytics_pages_new.pipe
@@ -1,0 +1,26 @@
+NODE analytics_pages_1
+DESCRIPTION >
+    Aggregate by pathname and calculate session and hits
+
+SQL >
+
+    SELECT
+        toDate(timestamp) AS date,
+        device,
+        browser,
+        location,
+        pathname,
+        uniqState(session_id) AS visits,
+        countState() AS hits
+    FROM analytics_hits_new
+    GROUP BY
+        date,
+        device,
+        browser,
+        location,
+        pathname
+
+TYPE materialized
+DATASOURCE analytics_pages_mv_new
+
+

--- a/change_sorting_key_to_s3_data_source/pipes/analytics_sessions_new.pipe
+++ b/change_sorting_key_to_s3_data_source/pipes/analytics_sessions_new.pipe
@@ -1,0 +1,24 @@
+NODE analytics_sessions_1
+DESCRIPTION >
+    Aggregate by session_id and calculate session metrics
+
+SQL >
+
+    SELECT
+        toDate(timestamp) AS date,
+        session_id,
+        anySimpleState(device) AS device,
+        anySimpleState(browser) AS browser,
+        anySimpleState(location) AS location,
+        minSimpleState(timestamp) AS first_hit,
+        maxSimpleState(timestamp) AS latest_hit,
+        countState() AS hits
+    FROM analytics_hits_new
+    GROUP BY
+        date,
+        session_id
+
+TYPE materialized
+DATASOURCE analytics_sessions_mv_new
+
+

--- a/change_sorting_key_to_s3_data_source/pipes/analytics_sources_new.pipe
+++ b/change_sorting_key_to_s3_data_source/pipes/analytics_sources_new.pipe
@@ -1,0 +1,33 @@
+NODE analytics_sources_1
+DESCRIPTION >
+    Aggregate by referral and calculate session and hits
+
+SQL >
+
+    WITH (
+            SELECT domainWithoutWWW(href)
+            FROM analytics_hits_new
+            WHERE href is not null and href != ''
+            LIMIT 1
+        ) AS currenct_domain
+    SELECT
+        toDate(timestamp) AS date,
+        device,
+        browser,
+        location,
+        referrer,
+        uniqState(session_id) AS visits,
+        countState() AS hits
+    FROM analytics_hits_new
+    WHERE domainWithoutWWW(referrer) != currenct_domain
+    GROUP BY
+        date,
+        device,
+        browser,
+        location,
+        referrer
+
+TYPE materialized
+DATASOURCE analytics_sources_mv_new
+
+

--- a/change_sorting_key_to_s3_data_source/pipes/new_data_sync.pipe
+++ b/change_sorting_key_to_s3_data_source/pipes/new_data_sync.pipe
@@ -13,7 +13,7 @@ SQL >
       payload
     FROM
       analytics_events
-    WHERE timestamp > '2023-11-30 08:00:00'
+    WHERE timestamp > '2023-11-30 13:40:00'
 
 TYPE materialized
 DATASOURCE analytics_events_new

--- a/change_sorting_key_to_s3_data_source/pipes/new_data_sync.pipe
+++ b/change_sorting_key_to_s3_data_source/pipes/new_data_sync.pipe
@@ -13,7 +13,7 @@ SQL >
       payload
     FROM
       analytics_events
-    WHERE timestamp > '2023-11-29 19:00:00'
+    WHERE timestamp > '2023-11-30 08:00:00'
 
 TYPE materialized
 DATASOURCE analytics_events_new

--- a/change_sorting_key_to_s3_data_source/pipes/new_data_sync.pipe
+++ b/change_sorting_key_to_s3_data_source/pipes/new_data_sync.pipe
@@ -1,0 +1,19 @@
+DESCRIPTION >
+	Materialized to move RT data from legacy to the new analytics_events datasource
+
+NODE materialize_on_analytics_events_new
+
+SQL >
+
+    SELECT
+      timestamp,
+      action,
+      version,
+      session_id,
+      payload
+    FROM
+      analytics_events
+    WHERE timestamp > '2023-11-29 19:00:00'
+
+TYPE materialized
+DATASOURCE analytics_events_new


### PR DESCRIPTION
The strategy followed to change the sorting key is:

1. Create the new Data Source with new Sorting Key and reading from a new S3 bucket/folder. In our example we're moving from `s3://webanalyticstb/v1/*.ndjson` to `s3://webanalyticstb/v2/*.ndjson`.

2. Duplicate and Sync the downstream for the new Data Source (without changing the endpoints yet). The downstream are all the resources depending on the Data Source.

3. Once the Data is in Sync, we'll change the endpoints to point the new downstream

4. Start storing the data for the new Data Source in the new bucket/folder then we can remove the legacy Data Source and its downstream.

This PR is for the points 1 and 2.